### PR TITLE
CLI doesn't work with Python >= 3.10

### DIFF
--- a/twint/cli.py
+++ b/twint/cli.py
@@ -331,8 +331,8 @@ def main():
 
 
 def run_as_command():
-    version = ".".join(str(v) for v in sys.version_info[:2])
-    if float(version) < 3.6:
+    version = sys.version_info[:2]
+    if version[0] < 3 or (version[0] == 3 and version[1] < 6):
         print("[-] TWINT requires Python version 3.6+.")
         sys.exit(0)
 


### PR DESCRIPTION
CLI doesn't work because of how to check Python version in cli.py.
The previous code cannot handle 3.10 because float('3.10') is 3.1, which is less than 3.6.  
https://github.com/twintproject/twint/pull/1309